### PR TITLE
Add support for Bitbucket Cloud and Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `filenameSafe` now removes query parameters and appends file name to the end of the link to preserve its original file extension.
-- Support for Bitbucket Cloud and Server ([#20](add-link-to-PR)).
+- Support for Bitbucket Cloud and Server ([#23](https://github.com/diffplug/blowdryer/pull/23)).
 
 ## [1.2.1] - 2021-06-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `filenameSafe` now, if required, removes query parameters (for Bitbucket) and appends file name to the end of the link to preserve its original file extension.
 - Support for Bitbucket Cloud and Server ([#23](https://github.com/diffplug/blowdryer/pull/23)).
 
 ## [1.2.1] - 2021-06-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `filenameSafe` now removes query parameters and appends file name to the end of the link to preserve its original file extension.
+- `filenameSafe` now, if required, removes query parameters (for Bitbucket) and appends file name to the end of the link to preserve its original file extension.
 - Support for Bitbucket Cloud and Server ([#23](https://github.com/diffplug/blowdryer/pull/23)).
 
 ## [1.2.1] - 2021-06-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `filenameSafe` now removes query parameters and appends file name to the end of the link to preserve its original file extension.
+- Support for Bitbucket Cloud and Server ([#20](add-link-to-PR)).
+
 ## [1.2.1] - 2021-06-01
 ### Fixed
 - `repoSubfolder` doesn't do anything in `localJar` mode, so setting `repoSubfolder` ought to be an error, and now it is ([#22](https://github.com/diffplug/blowdryer/pull/22)).

--- a/README.md
+++ b/README.md
@@ -55,14 +55,8 @@ blowdryerSetup {
   //                         or 'commit', '07f588e52eb0f31e596eab0228a5df7233a98a14'
   //                         or 'tree',   'a5df7233a98a1407f588e52eb0f31e596eab0228'
 
-  // or gitlab('acme/blowdryer-acme', 'tag', 'v1.4.5').customDomainHttp('acme.org').authToken('abc123')
-
-  // Public/Private Bitbucket Cloud repo configuration. Add .cloudAuth only for private repos.
-  // bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').cloudAuth("username:appPassword")
-
-  // Public/Private Bitbucket Server repo configurations. User .server for public repos. Use .serverAuth for private repos.
-  // bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').server().customDomainHttps('my.bitbucket.company.domain.com')
-  // or bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').serverAuth('personalAccessToken').customDomainHttps('my.bitbucket.company.domain.com')
+  // or gitlab('acme/blowdryer-acme', 'tag', 'v1.4.5').authToken('abc123').customDomainHttp('acme.org')
+  // or bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').authToken('abc123').customDomainHttps('acme.org')
 }
 ```
 * Reference on how to create [application password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,67 @@ somePlugin {
 
 `Blowdryer.prop()` parses a java `.properties` file which was downloaded using `Blowdryer.file()`, and then returns the value associated with the given key.
 
+### Bitbucket support
+#### Bitbucket Cloud
+
+For public Bitbucket Cloud repo, use such configuration:
+```gradle
+plugins {
+  id 'com.diffplug.blowdryerSetup' version '1.2.2'
+}
+
+blowdryerSetup {
+  bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5')
+  //                         or 'commit', '07f588e52eb0f31e596eab0228a5df7233a98a14'
+  //                         or 'branch',   'feature/branch'
+}
+```
+
+For private Bitbucket Cloud repo, use such configuration:
+```gradle
+plugins {
+  id 'com.diffplug.blowdryerSetup' version '1.2.2'
+}
+
+blowdryerSetup {
+  bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').cloudAuth("username:appPassword")
+  //                         or 'commit', '07f588e52eb0f31e596eab0228a5df7233a98a14'
+  //                         or 'branch',   'feature/branch'
+}
+```
+Reference on how to create [application password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/).
+
+#### Bitbucket Server
+
+For public Bitbucket Server repo, use such configuration:
+```gradle
+plugins {
+  id 'com.diffplug.blowdryerSetup' version '1.2.2'
+}
+
+blowdryerSetup {
+  bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').server()
+  // or bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').server().customDomainHttps('my.bitbucket.company.domain.com')
+  //                         or 'commit', '07f588e52eb0f31e596eab0228a5df7233a98a14'
+  //                         or 'branch',   'feature/branch'
+}
+```
+
+For private Bitbucket Server repo, use such configuration:
+```gradle
+plugins {
+  id 'com.diffplug.blowdryerSetup' version '1.2.2'
+}
+
+blowdryerSetup {
+  bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').serverAuth('personalAccessToken')
+  // or bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').serverAuth('personalAccessToken').customDomainHttps('my.bitbucket.company.domain.com')
+  //                         or 'commit', '07f588e52eb0f31e596eab0228a5df7233a98a14'
+  //                         or 'branch',   'feature/branch'
+}
+```
+Reference on how to create [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html).
+
 ### Chinese for "dry" (干)
 
 If you like brevity and unicode, you can replace `Blowdryer` with `干`.  We'll use `干` throughout the rest of the readme, but you can find-replace `干` with `Blowdryer` and get the same results.

--- a/README.md
+++ b/README.md
@@ -54,20 +54,20 @@ blowdryerSetup {
   github('acme/blowdryer-acme', 'tag', 'v1.4.5')
   //                         or 'commit', '07f588e52eb0f31e596eab0228a5df7233a98a14'
   //                         or 'tree',   'a5df7233a98a1407f588e52eb0f31e596eab0228'
-  
+
   // or gitlab('acme/blowdryer-acme', 'tag', 'v1.4.5').customDomainHttp('acme.org').authToken('abc123')
-  
-  // Public/Private Bitbucket Cloud repo configuration. Add .cloudAuth only for private repos. 
+
+  // Public/Private Bitbucket Cloud repo configuration. Add .cloudAuth only for private repos.
   // bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').cloudAuth("username:appPassword")
-  
+
   // Public/Private Bitbucket Server repo configurations. User .server for public repos. Use .serverAuth for private repos.
   // bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').server().customDomainHttps('my.bitbucket.company.domain.com')
   // or bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').serverAuth('personalAccessToken').customDomainHttps('my.bitbucket.company.domain.com')
 }
 ```
-* Reference on how to create [application password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) 
+* Reference on how to create [application password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/)
 for Bitbucket Cloud private repo access.<br/>
-* Reference on how to create [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) 
+* Reference on how to create [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html)
 for Bitbucket Server private repo access.
 
 Now, in *only* your root `build.gradle`, do this: `apply plugin: 'com.diffplug.blowdryer'`.  Now, in any project throughout your gradle build (including subprojects), you can do this:

--- a/README.md
+++ b/README.md
@@ -54,9 +54,21 @@ blowdryerSetup {
   github('acme/blowdryer-acme', 'tag', 'v1.4.5')
   //                         or 'commit', '07f588e52eb0f31e596eab0228a5df7233a98a14'
   //                         or 'tree',   'a5df7233a98a1407f588e52eb0f31e596eab0228'
+  
   // or gitlab('acme/blowdryer-acme', 'tag', 'v1.4.5').customDomainHttp('acme.org').authToken('abc123')
+  
+  // Public/Private Bitbucket Cloud repo configuration. Add .cloudAuth only for private repos. 
+  // bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').cloudAuth("username:appPassword")
+  
+  // Public/Private Bitbucket Server repo configurations. User .server for public repos. Use .serverAuth for private repos.
+  // bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').server().customDomainHttps('my.bitbucket.company.domain.com')
+  // or bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').serverAuth('personalAccessToken').customDomainHttps('my.bitbucket.company.domain.com')
 }
 ```
+* Reference on how to create [application password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) 
+for Bitbucket Cloud private repo access.<br/>
+* Reference on how to create [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) 
+for Bitbucket Server private repo access.
 
 Now, in *only* your root `build.gradle`, do this: `apply plugin: 'com.diffplug.blowdryer'`.  Now, in any project throughout your gradle build (including subprojects), you can do this:
 
@@ -71,67 +83,6 @@ somePlugin {
 `Blowdryer.file()` returns a `File` which was downloaded to your system temp directory, from the `src/main/resources` folder of `acme/blowdryer-acme`, at the `v1.4.5` tag.  Only one download will ever happen for the entire machine, and it will cache it until your system temp directory is cleaned.  To force a clean, you can run `gradlew blowdryerWipeEntireCache`.
 
 `Blowdryer.prop()` parses a java `.properties` file which was downloaded using `Blowdryer.file()`, and then returns the value associated with the given key.
-
-### Bitbucket support
-#### Bitbucket Cloud
-
-For public Bitbucket Cloud repo, use such configuration:
-```gradle
-plugins {
-  id 'com.diffplug.blowdryerSetup' version '1.2.2'
-}
-
-blowdryerSetup {
-  bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5')
-  //                         or 'commit', '07f588e52eb0f31e596eab0228a5df7233a98a14'
-  //                         or 'branch',   'feature/branch'
-}
-```
-
-For private Bitbucket Cloud repo, use such configuration:
-```gradle
-plugins {
-  id 'com.diffplug.blowdryerSetup' version '1.2.2'
-}
-
-blowdryerSetup {
-  bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').cloudAuth("username:appPassword")
-  //                         or 'commit', '07f588e52eb0f31e596eab0228a5df7233a98a14'
-  //                         or 'branch',   'feature/branch'
-}
-```
-Reference on how to create [application password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/).
-
-#### Bitbucket Server
-
-For public Bitbucket Server repo, use such configuration:
-```gradle
-plugins {
-  id 'com.diffplug.blowdryerSetup' version '1.2.2'
-}
-
-blowdryerSetup {
-  bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').server()
-  // or bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').server().customDomainHttps('my.bitbucket.company.domain.com')
-  //                         or 'commit', '07f588e52eb0f31e596eab0228a5df7233a98a14'
-  //                         or 'branch',   'feature/branch'
-}
-```
-
-For private Bitbucket Server repo, use such configuration:
-```gradle
-plugins {
-  id 'com.diffplug.blowdryerSetup' version '1.2.2'
-}
-
-blowdryerSetup {
-  bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').serverAuth('personalAccessToken')
-  // or bitbucket('acme/blowdryer-acme', 'tag', 'v1.4.5').serverAuth('personalAccessToken').customDomainHttps('my.bitbucket.company.domain.com')
-  //                         or 'commit', '07f588e52eb0f31e596eab0228a5df7233a98a14'
-  //                         or 'branch',   'feature/branch'
-}
-```
-Reference on how to create [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html).
 
 ### Chinese for "dry" (干)
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ apply from: 干.file('spotless/java.gradle')
 dependencies {
 	implementation 'com.squareup.okhttp3:okhttp:4.2.2'
 	implementation 'com.squareup.okio:okio:2.4.1'
+	implementation 'com.google.code.gson:gson:2.8.7'
 	implementation 'com.diffplug.durian:durian-core:1.2.0'
 	implementation 'com.diffplug.durian:durian-io:1.2.0'
 	testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
 	implementation 'com.squareup.okhttp3:okhttp:4.2.2'
 	implementation 'com.squareup.okio:okio:2.4.1'
 	implementation 'com.google.code.gson:gson:2.8.7'
+	implementation 'org.mockito:mockito-core:3.11.2'
 	implementation 'com.diffplug.durian:durian-core:1.2.0'
 	implementation 'com.diffplug.durian:durian-io:1.2.0'
 	testImplementation 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,9 @@ dependencies {
 	implementation 'com.squareup.okhttp3:okhttp:4.2.2'
 	implementation 'com.squareup.okio:okio:2.4.1'
 	implementation 'com.google.code.gson:gson:2.8.7'
-	implementation 'org.mockito:mockito-core:3.11.2'
 	implementation 'com.diffplug.durian:durian-core:1.2.0'
 	implementation 'com.diffplug.durian:durian-io:1.2.0'
 	testImplementation 'junit:junit:4.12'
 	testImplementation 'org.assertj:assertj-core:3.14.0'
+	testImplementation 'org.mockito:mockito-core:3.11.2'
 }

--- a/src/main/java/com/diffplug/blowdryer/Blowdryer.java
+++ b/src/main/java/com/diffplug/blowdryer/Blowdryer.java
@@ -47,6 +47,8 @@ import okio.BufferedSink;
 import okio.Okio;
 import org.gradle.api.Project;
 
+import static com.diffplug.blowdryer.BlowdryerSetup.BITBUCKET_COMMIT_HASH_CACHE;
+
 /**
  * Public static methods which retrieve resources as
  * determined by {@link BlowdryerSetup}.
@@ -72,6 +74,7 @@ public class Blowdryer {
 			try {
 				urlToContent.clear();
 				fileToProps.clear();
+				BITBUCKET_COMMIT_HASH_CACHE.clear();
 				java.nio.file.Files.walk(cacheDir.toPath())
 						.sorted(Comparator.reverseOrder())
 						.forEach(Errors.rethrow().wrap((Path path) -> java.nio.file.Files.delete(path)));
@@ -191,6 +194,11 @@ public class Blowdryer {
 
 	/** Returns either the filename safe URL, or (first40)--(Base64 filenamesafe)(last40). */
 	static String filenameSafe(String url) {
+		//preserve the filename and extension if query parameters are present in original url.
+		if (url.contains("?at")) {
+			String fileNameWithoutQuery = url.substring(0, url.indexOf("?at"));
+			url = String.format("%s-%s", url, fileNameWithoutQuery.substring(fileNameWithoutQuery.lastIndexOf("/") + 1));
+		}
 		String allSafeCharacters = url.replaceAll("[^a-zA-Z0-9-+_.]", "-");
 		String noDuplicateDash = allSafeCharacters.replaceAll("-+", "-");
 		if (noDuplicateDash.length() <= MAX_FILE_LENGTH) {
@@ -253,7 +261,8 @@ public class Blowdryer {
 		}
 	}
 
-	static interface AuthPlugin {
+	@FunctionalInterface
+	interface AuthPlugin {
 		void addAuthToken(String url, Request.Builder builder) throws MalformedURLException;
 	}
 

--- a/src/main/java/com/diffplug/blowdryer/Blowdryer.java
+++ b/src/main/java/com/diffplug/blowdryer/Blowdryer.java
@@ -101,11 +101,14 @@ public class Blowdryer {
 				if (metaFile.exists() && dataFile.exists()) {
 					Map<String, String> props = loadPropertyFile(metaFile);
 					String propUrl = props.get(PROP_URL);
+					if (propUrl == null) {
+						throw new IllegalArgumentException("Unexpected content, recommend deleting file at " + metaFile);
+					}
 					if (propUrl.equals(url)) {
 						urlToContent.put(url, dataFile);
 						return dataFile;
 					} else {
-						throw new IllegalStateException("Expected url " + url + " but was " + propUrl + " for " + metaFile.getAbsolutePath());
+						throw new IllegalStateException("Expected url " + url + " but was " + propUrl + ", recommend deleting file at " + metaFile.getAbsolutePath());
 					}
 				} else {
 					Files.createParentDirs(dataFile);

--- a/src/main/java/com/diffplug/blowdryer/Blowdryer.java
+++ b/src/main/java/com/diffplug/blowdryer/Blowdryer.java
@@ -191,7 +191,7 @@ public class Blowdryer {
 
 	/** Returns either the filename safe URL, or (first40)--(Base64 filenamesafe)(last40). */
 	static String filenameSafe(String url) {
-		url = detectAndRewriteBitbucketUrlIfRequired(url);
+		url = preserveFileExtensionBitbucket(url);
 		String allSafeCharacters = url.replaceAll("[^a-zA-Z0-9-+_.]", "-");
 		String noDuplicateDash = allSafeCharacters.replaceAll("-+", "-");
 		if (noDuplicateDash.length() <= MAX_FILE_LENGTH) {
@@ -214,9 +214,10 @@ public class Blowdryer {
 	// required to retrieve XML files.
 	// From: https://mycompany.bitbucket.com/projects/PRJ/repos/my-repo/raw/src/main/resources/checkstyle/spotless.gradle?at=07f588e52eb0f31e596eab0228a5df7233a98a14
 	// To:   https://mycompany.bitbucket.com/projects/PRJ/repos/my-repo/raw/src/main/resources/checkstyle/spotless.gradle?at=07f588e52eb0f31e596eab0228a5df7233a98a14-spotless.gradle
-	private static String detectAndRewriteBitbucketUrlIfRequired(String url) {
-		if (url.contains("?at")) {
-			String fileNameWithoutQuery = url.substring(0, url.indexOf("?at"));
+	private static String preserveFileExtensionBitbucket(String url) {
+		int atIdx = url.indexOf("?at=");
+		if (atIdx != -1) {
+			String fileNameWithoutQuery = url.substring(0, atIdx);
 			url = String.format("%s-%s", url, fileNameWithoutQuery.substring(fileNameWithoutQuery.lastIndexOf("/") + 1));
 		}
 		return url;

--- a/src/main/java/com/diffplug/blowdryer/BlowdryerSetup.java
+++ b/src/main/java/com/diffplug/blowdryer/BlowdryerSetup.java
@@ -194,28 +194,24 @@ public class BlowdryerSetup {
 			this.anchorType = anchorType;
 			this.bitbucketType = bitbucketType;
 			this.anchor = assertNoLeadingOrTrailingSlash(anchor);
-			customDomainHttps(BITBUCKET_HOST);
+			customProtocolAndDomain(BitbucketType.CLOUD, HTTPS_PROTOCOL, BITBUCKET_HOST);
 		}
 
-		public Bitbucket server() {
-			this.bitbucketType = BitbucketType.SERVER;
-			return setGlobals();
-		}
-
-		public Bitbucket auth(String auth) {
+		public Bitbucket authToken(String auth) {
 			this.auth = auth;
 			return setGlobals();
 		}
 
 		public Bitbucket customDomainHttp(String domain) {
-			return customProtocolAndDomain(HTTP_PROTOCOL, domain);
+			return customProtocolAndDomain(BitbucketType.SERVER, HTTP_PROTOCOL, domain);
 		}
 
 		public Bitbucket customDomainHttps(String domain) {
-			return customProtocolAndDomain(HTTPS_PROTOCOL, domain);
+			return customProtocolAndDomain(BitbucketType.SERVER, HTTPS_PROTOCOL, domain);
 		}
 
-		private Bitbucket customProtocolAndDomain(String protocol, String domain) {
+		private Bitbucket customProtocolAndDomain(BitbucketType type, String protocol, String domain) {
+			this.bitbucketType = type;
 			this.protocol = protocol;
 			this.host = domain;
 			return setGlobals();

--- a/src/main/java/com/diffplug/blowdryer/BlowdryerSetup.java
+++ b/src/main/java/com/diffplug/blowdryer/BlowdryerSetup.java
@@ -29,9 +29,7 @@ import java.util.Base64;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import javax.annotation.Nullable;
-
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Request.Builder;
@@ -218,7 +216,7 @@ public class BlowdryerSetup {
 		 */
 		public Bitbucket cloudAuth(String usernameAndAppPassword) {
 			final String encoding = Base64.getEncoder().encodeToString((usernameAndAppPassword)
-          .getBytes(StandardCharsets.UTF_8));
+					.getBytes(StandardCharsets.UTF_8));
 			this.authToken = String.format("Basic %s", encoding);
 			this.bitbucketType = BitbucketType.CLOUD;
 			return setGlobals();
@@ -276,50 +274,50 @@ public class BlowdryerSetup {
 
 		private String getAnchor() {
 			switch (anchorType) {
-				case COMMIT:
-					return anchor;
-				case TAG:
-					return String.format("refs/tags/%s", anchor);
-				default:
-					throw new UnsupportedOperationException(String.format("%s hash resolution is not supported.", anchorType));
+			case COMMIT:
+				return anchor;
+			case TAG:
+				return String.format("refs/tags/%s", anchor);
+			default:
+				throw new UnsupportedOperationException(String.format("%s hash resolution is not supported.", anchorType));
 			}
 		}
 
-    private String getAnchorForCloudAsHash() {
-      switch (anchorType) {
-				case COMMIT:
-					return anchor;
-        case TAG:
-          anchor = getCommitHash("refs/tags/");
-					anchorType = GitAnchorType.COMMIT;
-					return anchor;
-        default:
-					throw new UnsupportedOperationException("TREE hash resolution is not supported.");
-      }
-    }
+		private String getAnchorForCloudAsHash() {
+			switch (anchorType) {
+			case COMMIT:
+				return anchor;
+			case TAG:
+				anchor = getCommitHash("refs/tags/");
+				anchorType = GitAnchorType.COMMIT;
+				return anchor;
+			default:
+				throw new UnsupportedOperationException("TREE hash resolution is not supported.");
+			}
+		}
 
 		// Bitbucket API: https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Bworkspace%7D/%7Brepo_slug%7D/src/%7Bcommit%7D/%7Bpath%7D
 		private String getCommitHash(String baseRefs) {
 			String requestUrl = String.format("%s/%s%s", getUrlStart(), baseRefs, encodeUrlParts(anchor));
 
-      return getCommitHashFromBitbucket(requestUrl);
-    }
+			return getCommitHashFromBitbucket(requestUrl);
+		}
 
-    @VisibleForTesting
+		@VisibleForTesting
 		String getCommitHashFromBitbucket(String requestUrl) {
 			OkHttpClient client = new OkHttpClient.Builder().build();
 			Builder requestBuilder = new Builder()
-				.url(requestUrl);
+					.url(requestUrl);
 			if (authToken != null) {
 				requestBuilder
-					.addHeader("Authorization", authToken);
+						.addHeader("Authorization", authToken);
 			}
 			Request request = requestBuilder.build();
 
 			try (Response response = client.newCall(request).execute()) {
 				if (!response.isSuccessful()) {
 					throw new IllegalArgumentException(String.format("%s\nreceived http code %s \n %s", request.url(), response.code(),
-						Objects.requireNonNull(response.body()).string()));
+							Objects.requireNonNull(response.body()).string()));
 				}
 				try (ResponseBody body = response.body()) {
 					RefsTarget refsTarget = new Gson().fromJson(Objects.requireNonNull(body).string(), RefsTarget.class);
@@ -333,29 +331,29 @@ public class BlowdryerSetup {
 		// Do not encode '/'.
 		private String encodeUrlParts(String part) {
 			return Arrays.stream(part.split("/"))
-				.map(BlowdryerSetup::encodeUrlPart)
-				.collect(Collectors.joining("/"));
+					.map(BlowdryerSetup::encodeUrlPart)
+					.collect(Collectors.joining("/"));
 		}
 
 		private class RefsTarget {
 
-		    private final Target target;
+			private final Target target;
 
-        private RefsTarget(Target target) {
-            this.target = target;
-        }
+			private RefsTarget(Target target) {
+				this.target = target;
+			}
 
-        private class Target {
+			private class Target {
 
-		        private final String hash;
+				private final String hash;
 
-            private Target(String hash) {
-                this.hash = hash;
-            }
+				private Target(String hash) {
+					this.hash = hash;
+				}
 
-        }
-    }
-  }
+			}
+		}
+	}
 
 	/**
 	 * Uses the provided {@code jarFile} to extract a file resource.

--- a/src/test/java/com/diffplug/blowdryer/BlowdryerPluginAuthTest.java
+++ b/src/test/java/com/diffplug/blowdryer/BlowdryerPluginAuthTest.java
@@ -15,6 +15,7 @@
  */
 package com.diffplug.blowdryer;
 
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -54,20 +55,20 @@ public class BlowdryerPluginAuthTest extends GradleHarness {
 
 	private void settingsBitbucketBasicAuth(String tag, String... extra) throws IOException {
 		write("settings.gradle",
-			"plugins { id 'com.diffplug.blowdryerSetup' }",
-			String.format("blowdryerSetup { bitbucket('%s', 'commit', '%s').cloudAuth('%s:%s');",
-				BITBUCKET_REPO_ORG, tag, BITBUCKET_REPO_USER, BITBUCKET_REPO_APP_PW)
-				+ " }",
-			Arrays.stream(extra).collect(Collectors.joining("\n")));
+				"plugins { id 'com.diffplug.blowdryerSetup' }",
+				String.format("blowdryerSetup { bitbucket('%s', 'commit', '%s').cloudAuth('%s:%s');",
+						BITBUCKET_REPO_ORG, tag, BITBUCKET_REPO_USER, BITBUCKET_REPO_APP_PW)
+						+ " }",
+				Arrays.stream(extra).collect(Collectors.joining("\n")));
 	}
 
 	private void settingsBitbucketPersonalAccessTokenAuth(String tag, String... extra) throws IOException {
 		write("settings.gradle",
-			"plugins { id 'com.diffplug.blowdryerSetup' }",
-			String.format("blowdryerSetup { bitbucket('%s', 'commit', '%s').customDomainHttps('%s')"
-				+ ".serverAuth('%s');", BITBUCKET_REPO_PAT_REPO_ORG, tag, BITBUCKET_PRIVATE_SERVER_HOST, BITBUCKET_REPO_PAT)
-				+ " }",
-			Arrays.stream(extra).collect(Collectors.joining("\n")));
+				"plugins { id 'com.diffplug.blowdryerSetup' }",
+				String.format("blowdryerSetup { bitbucket('%s', 'commit', '%s').customDomainHttps('%s')"
+						+ ".serverAuth('%s');", BITBUCKET_REPO_PAT_REPO_ORG, tag, BITBUCKET_PRIVATE_SERVER_HOST, BITBUCKET_REPO_PAT)
+						+ " }",
+				Arrays.stream(extra).collect(Collectors.joining("\n")));
 	}
 
 	@Test
@@ -92,8 +93,8 @@ public class BlowdryerPluginAuthTest extends GradleHarness {
 	public void bitbucketCloudAuth() throws IOException {
 		settingsBitbucketBasicAuth("master");
 		write("build.gradle",
-			"apply plugin: 'com.diffplug.blowdryer'",
-			"assert 干.file('sample').text == 'a'");
+				"apply plugin: 'com.diffplug.blowdryer'",
+				"assert 干.file('sample').text == 'a'");
 		gradleRunner().build();
 	}
 
@@ -101,8 +102,8 @@ public class BlowdryerPluginAuthTest extends GradleHarness {
 	public void bitbucketServerAuth() throws IOException {
 		settingsBitbucketPersonalAccessTokenAuth("master");
 		write("build.gradle",
-			"apply plugin: 'com.diffplug.blowdryer'",
-			"assert 干.file('checkstyle/spotless.gradle').text == 'a'");
+				"apply plugin: 'com.diffplug.blowdryer'",
+				"assert 干.file('checkstyle/spotless.gradle').text == 'a'");
 		gradleRunner().build();
 	}
 

--- a/src/test/java/com/diffplug/blowdryer/BlowdryerPluginAuthTest.java
+++ b/src/test/java/com/diffplug/blowdryer/BlowdryerPluginAuthTest.java
@@ -55,7 +55,7 @@ public class BlowdryerPluginAuthTest extends GradleHarness {
 	private void settingsBitbucketBasicAuth(String tag, String... extra) throws IOException {
 		write("settings.gradle",
 			"plugins { id 'com.diffplug.blowdryerSetup' }",
-			String.format("blowdryerSetup { bitbucket('%s', 'tree', '%s').cloudAuth('%s:%s');",
+			String.format("blowdryerSetup { bitbucket('%s', 'commit', '%s').cloudAuth('%s:%s');",
 				BITBUCKET_REPO_ORG, tag, BITBUCKET_REPO_USER, BITBUCKET_REPO_APP_PW)
 				+ " }",
 			Arrays.stream(extra).collect(Collectors.joining("\n")));
@@ -64,7 +64,7 @@ public class BlowdryerPluginAuthTest extends GradleHarness {
 	private void settingsBitbucketPersonalAccessTokenAuth(String tag, String... extra) throws IOException {
 		write("settings.gradle",
 			"plugins { id 'com.diffplug.blowdryerSetup' }",
-			String.format("blowdryerSetup { bitbucket('%s', 'tree', '%s').customDomainHttps('%s')"
+			String.format("blowdryerSetup { bitbucket('%s', 'commit', '%s').customDomainHttps('%s')"
 				+ ".serverAuth('%s');", BITBUCKET_REPO_PAT_REPO_ORG, tag, BITBUCKET_PRIVATE_SERVER_HOST, BITBUCKET_REPO_PAT)
 				+ " }",
 			Arrays.stream(extra).collect(Collectors.joining("\n")));

--- a/src/test/java/com/diffplug/blowdryer/BlowdryerPluginAuthTest.java
+++ b/src/test/java/com/diffplug/blowdryer/BlowdryerPluginAuthTest.java
@@ -15,7 +15,6 @@
  */
 package com.diffplug.blowdryer;
 
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -25,8 +24,16 @@ import java.util.stream.Collectors;
 import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore("has to be filled with prvate tokens and repos")
+@Ignore("has to be filled with private tokens and repos")
 public class BlowdryerPluginAuthTest extends GradleHarness {
+
+	private static final String BITBUCKET_REPO_ORG = "bHack/blowdryer-private";
+	private static final String BITBUCKET_REPO_USER = "bHack";
+	private static final String BITBUCKET_REPO_APP_PW = "replace-with-app-pw";
+
+	private static final String BITBUCKET_REPO_PAT_REPO_ORG = "MNT/mnt-centralised-cfg";
+	private static final String BITBUCKET_REPO_PAT = "replace-with-pat";
+	private static final String BITBUCKET_PRIVATE_SERVER_HOST = "replace.with.private.host";
 
 	private void settingsGitlabAuth(String tag, String... extra) throws IOException {
 		write("settings.gradle",
@@ -45,6 +52,24 @@ public class BlowdryerPluginAuthTest extends GradleHarness {
 				Arrays.stream(extra).collect(Collectors.joining("\n")));
 	}
 
+	private void settingsBitbucketBasicAuth(String tag, String... extra) throws IOException {
+		write("settings.gradle",
+			"plugins { id 'com.diffplug.blowdryerSetup' }",
+			String.format("blowdryerSetup { bitbucket('%s', 'tree', '%s').cloudAuth('%s:%s');",
+				BITBUCKET_REPO_ORG, tag, BITBUCKET_REPO_USER, BITBUCKET_REPO_APP_PW)
+				+ " }",
+			Arrays.stream(extra).collect(Collectors.joining("\n")));
+	}
+
+	private void settingsBitbucketPersonalAccessTokenAuth(String tag, String... extra) throws IOException {
+		write("settings.gradle",
+			"plugins { id 'com.diffplug.blowdryerSetup' }",
+			String.format("blowdryerSetup { bitbucket('%s', 'tree', '%s').customDomainHttps('%s')"
+				+ ".serverAuth('%s');", BITBUCKET_REPO_PAT_REPO_ORG, tag, BITBUCKET_PRIVATE_SERVER_HOST, BITBUCKET_REPO_PAT)
+				+ " }",
+			Arrays.stream(extra).collect(Collectors.joining("\n")));
+	}
+
 	@Test
 	public void githubAuthTag() throws IOException {
 		settingsGithubAuth("master");
@@ -60,6 +85,24 @@ public class BlowdryerPluginAuthTest extends GradleHarness {
 		write("build.gradle",
 				"apply plugin: 'com.diffplug.blowdryer'",
 				"assert 干.file('sample').text == 'a'");
+		gradleRunner().build();
+	}
+
+	@Test
+	public void bitbucketCloudAuth() throws IOException {
+		settingsBitbucketBasicAuth("master");
+		write("build.gradle",
+			"apply plugin: 'com.diffplug.blowdryer'",
+			"assert 干.file('sample').text == 'a'");
+		gradleRunner().build();
+	}
+
+	@Test
+	public void bitbucketServerAuth() throws IOException {
+		settingsBitbucketPersonalAccessTokenAuth("master");
+		write("build.gradle",
+			"apply plugin: 'com.diffplug.blowdryer'",
+			"assert 干.file('checkstyle/spotless.gradle').text == 'a'");
 		gradleRunner().build();
 	}
 

--- a/src/test/java/com/diffplug/blowdryer/BlowdryerPluginTest.java
+++ b/src/test/java/com/diffplug/blowdryer/BlowdryerPluginTest.java
@@ -26,8 +26,7 @@ public class BlowdryerPluginTest extends GradleHarness {
 
 	private static final String SETTINGS_GRADLE = "settings.gradle";
 	private static final String BUILD_GRADLE = "build.gradle";
-	//todo: change to diffplug if created
-	private static final String BITBUCKET_REPO_ORG = "bHack";
+	private static final String BITBUCKET_REPO_ORG = "diffplug";
 
 	private void settingsGithub(String tag, String... extra) throws IOException {
 		write(SETTINGS_GRADLE,
@@ -61,21 +60,6 @@ public class BlowdryerPluginTest extends GradleHarness {
 		write(SETTINGS_GRADLE,
 				"plugins { id 'com.diffplug.blowdryerSetup' }",
 				String.format("blowdryerSetup { bitbucket('%s/blowdryer', 'tag', '%s') }", BITBUCKET_REPO_ORG, tag),
-				Arrays.stream(extra).collect(Collectors.joining("\n")));
-	}
-
-	private void settingsCustomBitbucket(String tag, String... extra) throws IOException {
-		write(SETTINGS_GRADLE,
-				"plugins { id 'com.diffplug.blowdryerSetup' }",
-				String.format("blowdryerSetup { bitbucket('%s/blowdryer', 'tag', '%s').customDomainHttps('api.bitbucket.org/2.0/repositories') }",
-						BITBUCKET_REPO_ORG, tag),
-				Arrays.stream(extra).collect(Collectors.joining("\n")));
-	}
-
-	private void settingsCustomBitbucket(String tag, int host, String... extra) throws IOException {
-		write(SETTINGS_GRADLE,
-				"plugins { id 'com.diffplug.blowdryerSetup' }",
-				String.format("blowdryerSetup { bitbucket('%s/blowdryer', 'tag', '%s').customDomainHttps('%s') }", BITBUCKET_REPO_ORG, tag, host),
 				Arrays.stream(extra).collect(Collectors.joining("\n")));
 	}
 
@@ -183,39 +167,6 @@ public class BlowdryerPluginTest extends GradleHarness {
 
 		// double-check that failures do fail
 		settingsCustomGitlab("test/2/b");
-		write(BUILD_GRADLE,
-				"plugins { id 'com.diffplug.blowdryer' }",
-				"assert Blowdryer.file('sample').text == 'a'");
-		gradleRunner().buildAndFail();
-	}
-
-	@Test
-	public void customBitbucketTag() throws IOException {
-		settingsCustomBitbucket("test/2/a");
-		write(BUILD_GRADLE,
-				"apply plugin: 'com.diffplug.blowdryer'",
-				"assert 干.file('sample').text == 'a'",
-				"assert 干.prop('sample', 'name') == 'test'",
-				"assert 干.prop('sample', 'ver_spotless') == '1.2.0'");
-		gradleRunner().build();
-
-		settingsCustomBitbucket("test/2/b");
-		write(BUILD_GRADLE,
-				"apply plugin: 'com.diffplug.blowdryer'",
-				"assert 干.file('sample').text == 'b'",
-				"assert 干.prop('sample', 'name') == 'testB'",
-				"assert 干.prop('sample', 'group') == 'com.diffplug.gradleB'");
-		gradleRunner().build();
-
-		// double-check that failures do fail
-		settingsCustomBitbucket("test/2/b");
-		write(BUILD_GRADLE,
-				"plugins { id 'com.diffplug.blowdryer' }",
-				"assert Blowdryer.file('sample').text == 'a'");
-		gradleRunner().buildAndFail();
-
-		// unresolved host
-		settingsCustomBitbucket("test/2/b", 123);
 		write(BUILD_GRADLE,
 				"plugins { id 'com.diffplug.blowdryer' }",
 				"assert Blowdryer.file('sample').text == 'a'");

--- a/src/test/java/com/diffplug/blowdryer/BlowdryerPluginTest.java
+++ b/src/test/java/com/diffplug/blowdryer/BlowdryerPluginTest.java
@@ -26,6 +26,8 @@ public class BlowdryerPluginTest extends GradleHarness {
 
 	private static final String SETTINGS_GRADLE = "settings.gradle";
 	private static final String BUILD_GRADLE = "build.gradle";
+	//todo: change to diffplug if created
+	private static final String BITBUCKET_REPO_ORG = "bHack";
 
 	private void settingsGithub(String tag, String... extra) throws IOException {
 		write(SETTINGS_GRADLE,
@@ -53,6 +55,28 @@ public class BlowdryerPluginTest extends GradleHarness {
 				"plugins { id 'com.diffplug.blowdryerSetup' }",
 				"blowdryerSetup { repoSubfolder(''); gitlab('diffplug/blowdryer', 'tag', '" + tag + "') }",
 				Arrays.stream(extra).collect(Collectors.joining("\n")));
+	}
+
+	private void settingsBitbucket(String tag, String... extra) throws IOException {
+		write(SETTINGS_GRADLE,
+			"plugins { id 'com.diffplug.blowdryerSetup' }",
+			String.format("blowdryerSetup { bitbucket('%s/blowdryer', 'tag', '%s') }", BITBUCKET_REPO_ORG, tag),
+			Arrays.stream(extra).collect(Collectors.joining("\n")));
+	}
+
+	private void settingsCustomBitbucket(String tag, String... extra) throws IOException {
+		write(SETTINGS_GRADLE,
+			"plugins { id 'com.diffplug.blowdryerSetup' }",
+			String.format("blowdryerSetup { bitbucket('%s/blowdryer', 'tag', '%s').customDomainHttps('api.bitbucket.org/2.0/repositories') }",
+				BITBUCKET_REPO_ORG, tag),
+			Arrays.stream(extra).collect(Collectors.joining("\n")));
+	}
+
+	private void settingsCustomBitbucket(String tag, int host, String... extra) throws IOException {
+		write(SETTINGS_GRADLE,
+			"plugins { id 'com.diffplug.blowdryerSetup' }",
+			String.format("blowdryerSetup { bitbucket('%s/blowdryer', 'tag', '%s').customDomainHttps('%s') }", BITBUCKET_REPO_ORG, tag, host),
+			Arrays.stream(extra).collect(Collectors.joining("\n")));
 	}
 
 	private void settingsLocalJar(String dependency) throws IOException {
@@ -114,6 +138,32 @@ public class BlowdryerPluginTest extends GradleHarness {
 	}
 
 	@Test
+	public void bitbucketTag() throws IOException {
+		settingsBitbucket("test/2/a");
+		write(BUILD_GRADLE,
+			"apply plugin: 'com.diffplug.blowdryer'",
+			"assert 干.file('sample').text == 'a'",
+			"assert 干.prop('sample', 'name') == 'test'",
+			"assert 干.prop('sample', 'ver_spotless') == '1.2.0'");
+		gradleRunner().build();
+
+		settingsBitbucket("test/2/b");
+		write(BUILD_GRADLE,
+			"apply plugin: 'com.diffplug.blowdryer'",
+			"assert 干.file('sample').text == 'b'",
+			"assert 干.prop('sample', 'name') == 'testB'",
+			"assert 干.prop('sample', 'group') == 'com.diffplug.gradleB'");
+		gradleRunner().build();
+
+		// double-check that failures do fail
+		settingsBitbucket("test/2/b");
+		write(BUILD_GRADLE,
+			"plugins { id 'com.diffplug.blowdryer' }",
+			"assert Blowdryer.file('sample').text == 'a'");
+		gradleRunner().buildAndFail();
+	}
+
+	@Test
 	public void customGitlabTag() throws IOException {
 		settingsCustomGitlab("test/2/a");
 		write(BUILD_GRADLE,
@@ -136,6 +186,39 @@ public class BlowdryerPluginTest extends GradleHarness {
 		write(BUILD_GRADLE,
 				"plugins { id 'com.diffplug.blowdryer' }",
 				"assert Blowdryer.file('sample').text == 'a'");
+		gradleRunner().buildAndFail();
+	}
+
+	@Test
+	public void customBitbucketTag() throws IOException {
+		settingsCustomBitbucket("test/2/a");
+		write(BUILD_GRADLE,
+			"apply plugin: 'com.diffplug.blowdryer'",
+			"assert 干.file('sample').text == 'a'",
+			"assert 干.prop('sample', 'name') == 'test'",
+			"assert 干.prop('sample', 'ver_spotless') == '1.2.0'");
+		gradleRunner().build();
+
+		settingsCustomBitbucket("test/2/b");
+		write(BUILD_GRADLE,
+			"apply plugin: 'com.diffplug.blowdryer'",
+			"assert 干.file('sample').text == 'b'",
+			"assert 干.prop('sample', 'name') == 'testB'",
+			"assert 干.prop('sample', 'group') == 'com.diffplug.gradleB'");
+		gradleRunner().build();
+
+		// double-check that failures do fail
+		settingsCustomBitbucket("test/2/b");
+		write(BUILD_GRADLE,
+			"plugins { id 'com.diffplug.blowdryer' }",
+			"assert Blowdryer.file('sample').text == 'a'");
+		gradleRunner().buildAndFail();
+
+		// unresolved host
+		settingsCustomBitbucket("test/2/b", 123);
+		write(BUILD_GRADLE,
+			"plugins { id 'com.diffplug.blowdryer' }",
+			"assert Blowdryer.file('sample').text == 'a'");
 		gradleRunner().buildAndFail();
 	}
 

--- a/src/test/java/com/diffplug/blowdryer/BlowdryerPluginTest.java
+++ b/src/test/java/com/diffplug/blowdryer/BlowdryerPluginTest.java
@@ -59,24 +59,24 @@ public class BlowdryerPluginTest extends GradleHarness {
 
 	private void settingsBitbucket(String tag, String... extra) throws IOException {
 		write(SETTINGS_GRADLE,
-			"plugins { id 'com.diffplug.blowdryerSetup' }",
-			String.format("blowdryerSetup { bitbucket('%s/blowdryer', 'tag', '%s') }", BITBUCKET_REPO_ORG, tag),
-			Arrays.stream(extra).collect(Collectors.joining("\n")));
+				"plugins { id 'com.diffplug.blowdryerSetup' }",
+				String.format("blowdryerSetup { bitbucket('%s/blowdryer', 'tag', '%s') }", BITBUCKET_REPO_ORG, tag),
+				Arrays.stream(extra).collect(Collectors.joining("\n")));
 	}
 
 	private void settingsCustomBitbucket(String tag, String... extra) throws IOException {
 		write(SETTINGS_GRADLE,
-			"plugins { id 'com.diffplug.blowdryerSetup' }",
-			String.format("blowdryerSetup { bitbucket('%s/blowdryer', 'tag', '%s').customDomainHttps('api.bitbucket.org/2.0/repositories') }",
-				BITBUCKET_REPO_ORG, tag),
-			Arrays.stream(extra).collect(Collectors.joining("\n")));
+				"plugins { id 'com.diffplug.blowdryerSetup' }",
+				String.format("blowdryerSetup { bitbucket('%s/blowdryer', 'tag', '%s').customDomainHttps('api.bitbucket.org/2.0/repositories') }",
+						BITBUCKET_REPO_ORG, tag),
+				Arrays.stream(extra).collect(Collectors.joining("\n")));
 	}
 
 	private void settingsCustomBitbucket(String tag, int host, String... extra) throws IOException {
 		write(SETTINGS_GRADLE,
-			"plugins { id 'com.diffplug.blowdryerSetup' }",
-			String.format("blowdryerSetup { bitbucket('%s/blowdryer', 'tag', '%s').customDomainHttps('%s') }", BITBUCKET_REPO_ORG, tag, host),
-			Arrays.stream(extra).collect(Collectors.joining("\n")));
+				"plugins { id 'com.diffplug.blowdryerSetup' }",
+				String.format("blowdryerSetup { bitbucket('%s/blowdryer', 'tag', '%s').customDomainHttps('%s') }", BITBUCKET_REPO_ORG, tag, host),
+				Arrays.stream(extra).collect(Collectors.joining("\n")));
 	}
 
 	private void settingsLocalJar(String dependency) throws IOException {
@@ -141,25 +141,25 @@ public class BlowdryerPluginTest extends GradleHarness {
 	public void bitbucketTag() throws IOException {
 		settingsBitbucket("test/2/a");
 		write(BUILD_GRADLE,
-			"apply plugin: 'com.diffplug.blowdryer'",
-			"assert 干.file('sample').text == 'a'",
-			"assert 干.prop('sample', 'name') == 'test'",
-			"assert 干.prop('sample', 'ver_spotless') == '1.2.0'");
+				"apply plugin: 'com.diffplug.blowdryer'",
+				"assert 干.file('sample').text == 'a'",
+				"assert 干.prop('sample', 'name') == 'test'",
+				"assert 干.prop('sample', 'ver_spotless') == '1.2.0'");
 		gradleRunner().build();
 
 		settingsBitbucket("test/2/b");
 		write(BUILD_GRADLE,
-			"apply plugin: 'com.diffplug.blowdryer'",
-			"assert 干.file('sample').text == 'b'",
-			"assert 干.prop('sample', 'name') == 'testB'",
-			"assert 干.prop('sample', 'group') == 'com.diffplug.gradleB'");
+				"apply plugin: 'com.diffplug.blowdryer'",
+				"assert 干.file('sample').text == 'b'",
+				"assert 干.prop('sample', 'name') == 'testB'",
+				"assert 干.prop('sample', 'group') == 'com.diffplug.gradleB'");
 		gradleRunner().build();
 
 		// double-check that failures do fail
 		settingsBitbucket("test/2/b");
 		write(BUILD_GRADLE,
-			"plugins { id 'com.diffplug.blowdryer' }",
-			"assert Blowdryer.file('sample').text == 'a'");
+				"plugins { id 'com.diffplug.blowdryer' }",
+				"assert Blowdryer.file('sample').text == 'a'");
 		gradleRunner().buildAndFail();
 	}
 
@@ -193,32 +193,32 @@ public class BlowdryerPluginTest extends GradleHarness {
 	public void customBitbucketTag() throws IOException {
 		settingsCustomBitbucket("test/2/a");
 		write(BUILD_GRADLE,
-			"apply plugin: 'com.diffplug.blowdryer'",
-			"assert 干.file('sample').text == 'a'",
-			"assert 干.prop('sample', 'name') == 'test'",
-			"assert 干.prop('sample', 'ver_spotless') == '1.2.0'");
+				"apply plugin: 'com.diffplug.blowdryer'",
+				"assert 干.file('sample').text == 'a'",
+				"assert 干.prop('sample', 'name') == 'test'",
+				"assert 干.prop('sample', 'ver_spotless') == '1.2.0'");
 		gradleRunner().build();
 
 		settingsCustomBitbucket("test/2/b");
 		write(BUILD_GRADLE,
-			"apply plugin: 'com.diffplug.blowdryer'",
-			"assert 干.file('sample').text == 'b'",
-			"assert 干.prop('sample', 'name') == 'testB'",
-			"assert 干.prop('sample', 'group') == 'com.diffplug.gradleB'");
+				"apply plugin: 'com.diffplug.blowdryer'",
+				"assert 干.file('sample').text == 'b'",
+				"assert 干.prop('sample', 'name') == 'testB'",
+				"assert 干.prop('sample', 'group') == 'com.diffplug.gradleB'");
 		gradleRunner().build();
 
 		// double-check that failures do fail
 		settingsCustomBitbucket("test/2/b");
 		write(BUILD_GRADLE,
-			"plugins { id 'com.diffplug.blowdryer' }",
-			"assert Blowdryer.file('sample').text == 'a'");
+				"plugins { id 'com.diffplug.blowdryer' }",
+				"assert Blowdryer.file('sample').text == 'a'");
 		gradleRunner().buildAndFail();
 
 		// unresolved host
 		settingsCustomBitbucket("test/2/b", 123);
 		write(BUILD_GRADLE,
-			"plugins { id 'com.diffplug.blowdryer' }",
-			"assert Blowdryer.file('sample').text == 'a'");
+				"plugins { id 'com.diffplug.blowdryer' }",
+				"assert Blowdryer.file('sample').text == 'a'");
 		gradleRunner().buildAndFail();
 	}
 

--- a/src/test/java/com/diffplug/blowdryer/BlowdryerTest.java
+++ b/src/test/java/com/diffplug/blowdryer/BlowdryerTest.java
@@ -15,24 +15,22 @@
  */
 package com.diffplug.blowdryer;
 
-import com.diffplug.blowdryer.Blowdryer.AuthPlugin;
-import com.diffplug.blowdryer.Blowdryer.ResourcePlugin;
-import com.diffplug.blowdryer.BlowdryerSetup.Bitbucket;
-import com.diffplug.blowdryer.BlowdryerSetup.GitAnchorType;
-import okhttp3.Request;
-import okhttp3.Request.Builder;
-import org.junit.Test;
-
-import java.lang.reflect.Field;
-import java.util.Base64;
-import java.util.UUID;
-
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
+import com.diffplug.blowdryer.Blowdryer.AuthPlugin;
+import com.diffplug.blowdryer.Blowdryer.ResourcePlugin;
+import com.diffplug.blowdryer.BlowdryerSetup.Bitbucket;
+import com.diffplug.blowdryer.BlowdryerSetup.GitAnchorType;
+import java.lang.reflect.Field;
+import java.util.Base64;
+import java.util.UUID;
+import okhttp3.Request;
+import okhttp3.Request.Builder;
+import org.junit.Test;
 
 public class BlowdryerTest {
 	private static final String JAR_FILE_RESOURCE_SEPARATOR = "!/";
@@ -44,9 +42,9 @@ public class BlowdryerTest {
 		filenameSafe("https://raw.githubusercontent.com/diffplug/durian-build/07f588e52eb0f31e596eab0228a5df7233a98a14/gradle/spotless/spotless.license.java",
 				"https-raw.githubusercontent.com-diffplug--3vpUTw--14-gradle-spotless-spotless.license.java");
 		filenameSafe("https://mycompany.bitbucket.com/projects/PRJ/repos/my-repo/raw/src/main/resources/checkstyle/spotless.gradle?at=refs%2Fheads%2Fmaster",
-			"https-mycompany.bitbucket.com-projects-P--7T3UGg--at-refs-2Fheads-2Fmaster-spotless.gradle");
+				"https-mycompany.bitbucket.com-projects-P--7T3UGg--at-refs-2Fheads-2Fmaster-spotless.gradle");
 		filenameSafe("https://mycompany.bitbucket.com/projects/PRJ/repos/my-repo/raw/src/main/resources/checkstyle/spotless.gradle?at=07f588e52eb0f31e596eab0228a5df7233a98a14",
-			"https-mycompany.bitbucket.com-projects-P--K+HRow--596eab0228a5df7233a98a14-spotless.gradle");
+				"https-mycompany.bitbucket.com-projects-P--K+HRow--596eab0228a5df7233a98a14-spotless.gradle");
 	}
 
 	private void filenameSafe(String url, String safe) {
@@ -95,8 +93,8 @@ public class BlowdryerTest {
 		final ResourcePlugin target = getResourcePlugin();
 
 		assertThatThrownBy(() -> target.toImmutableUrl("test.properties"))
-			.isInstanceOf(UnsupportedOperationException.class)
-			.hasMessage("TREE hash resolution is not supported.");
+				.isInstanceOf(UnsupportedOperationException.class)
+				.hasMessage("TREE hash resolution is not supported.");
 	}
 
 	@Test
@@ -123,14 +121,14 @@ public class BlowdryerTest {
 		final ResourcePlugin target = getResourcePlugin();
 
 		assertThatThrownBy(() -> target.toImmutableUrl("test.properties"))
-			.isInstanceOf(UnsupportedOperationException.class)
-			.hasMessage("TREE hash resolution is not supported.");
+				.isInstanceOf(UnsupportedOperationException.class)
+				.hasMessage("TREE hash resolution is not supported.");
 	}
 
 	@Test
 	public void bitbucketCloudAuth() throws Exception {
 		final String expected = "https://api.bitbucket.org/2.0/repositories/testOrg/testRepo/src/testAnchor/src/main/resources/test.properties";
-    final String usernameAndAppPassword = String.format("%s:%s", randomUUID(), randomUUID());
+		final String usernameAndAppPassword = String.format("%s:%s", randomUUID(), randomUUID());
 		setupBitbucketTestTarget(GitAnchorType.COMMIT).cloudAuth(usernameAndAppPassword);
 
 		final ResourcePlugin target = getResourcePlugin();
@@ -141,7 +139,7 @@ public class BlowdryerTest {
 
 		assertThat(target.toImmutableUrl("test.properties")).isEqualTo(expected);
 		final String encoded = Base64.getEncoder().encodeToString((usernameAndAppPassword)
-			.getBytes(UTF_8));
+				.getBytes(UTF_8));
 		assertThat(request.header("Authorization")).isEqualTo(String.format("Basic %s", encoded));
 	}
 

--- a/src/test/java/com/diffplug/blowdryer/BlowdryerTest.java
+++ b/src/test/java/com/diffplug/blowdryer/BlowdryerTest.java
@@ -71,7 +71,7 @@ public class BlowdryerTest {
 		final String hash = UUID.randomUUID().toString();
 		final String expected = "https://api.bitbucket.org/2.0/repositories/testOrg/testRepo/src/" + hash + "/src/main/resources/test.properties";
 
-		Bitbucket spy = spy(setupBitbucketTestTarget(GitAnchorType.TAG)).cloudAuth("un:pw");
+		Bitbucket spy = spy(setupBitbucketTestTarget(GitAnchorType.TAG)).authToken("un:pw");
 		doReturn(hash).when(spy).getCommitHashFromBitbucket(hashRequestUrl);
 		final ResourcePlugin target = getResourcePlugin();
 
@@ -94,13 +94,13 @@ public class BlowdryerTest {
 
 		assertThatThrownBy(() -> target.toImmutableUrl("test.properties"))
 				.isInstanceOf(UnsupportedOperationException.class)
-				.hasMessage("TREE hash resolution is not supported.");
+				.hasMessage("TREE not supported for Bitbucket");
 	}
 
 	@Test
 	public void bitbucketServer_tagAnchorType() throws Exception {
 		final String expected = "https://my.bitbucket.com/projects/testOrg/repos/testRepo/raw/src/main/resources/test.properties?at=refs%2Ftags%2FtestAnchor";
-		setupBitbucketTestTarget(GitAnchorType.TAG).server().customDomainHttps("my.bitbucket.com");
+		setupBitbucketTestTarget(GitAnchorType.TAG).customDomainHttps("my.bitbucket.com");
 		final ResourcePlugin target = getResourcePlugin();
 
 		assertThat(target.toImmutableUrl("test.properties")).isEqualTo(expected);
@@ -109,7 +109,7 @@ public class BlowdryerTest {
 	@Test
 	public void bitbucketServer_commitAnchorType() throws Exception {
 		final String expected = "https://my.bitbucket.com/projects/testOrg/repos/testRepo/raw/src/main/resources/test.properties?at=testAnchor";
-		setupBitbucketTestTarget(GitAnchorType.COMMIT).server().customDomainHttps("my.bitbucket.com");
+		setupBitbucketTestTarget(GitAnchorType.COMMIT).customDomainHttps("my.bitbucket.com");
 		final ResourcePlugin target = getResourcePlugin();
 
 		assertThat(target.toImmutableUrl("test.properties")).isEqualTo(expected);
@@ -117,19 +117,19 @@ public class BlowdryerTest {
 
 	@Test
 	public void bitbucketServer_treeAnchorType() throws Exception {
-		setupBitbucketTestTarget(GitAnchorType.TREE).server().customDomainHttps("my.bitbucket.com");
+		setupBitbucketTestTarget(GitAnchorType.TREE).customDomainHttps("my.bitbucket.com");
 		final ResourcePlugin target = getResourcePlugin();
 
 		assertThatThrownBy(() -> target.toImmutableUrl("test.properties"))
 				.isInstanceOf(UnsupportedOperationException.class)
-				.hasMessage("TREE hash resolution is not supported.");
+				.hasMessage("TREE not supported for Bitbucket");
 	}
 
 	@Test
 	public void bitbucketCloudAuth() throws Exception {
 		final String expected = "https://api.bitbucket.org/2.0/repositories/testOrg/testRepo/src/testAnchor/src/main/resources/test.properties";
 		final String usernameAndAppPassword = String.format("%s:%s", randomUUID(), randomUUID());
-		setupBitbucketTestTarget(GitAnchorType.COMMIT).cloudAuth(usernameAndAppPassword);
+		setupBitbucketTestTarget(GitAnchorType.COMMIT).authToken(usernameAndAppPassword);
 
 		final ResourcePlugin target = getResourcePlugin();
 		final AuthPlugin otherTarget = getAuthPlugin();

--- a/src/test/java/com/diffplug/blowdryer/BlowdryerTest.java
+++ b/src/test/java/com/diffplug/blowdryer/BlowdryerTest.java
@@ -15,9 +15,23 @@
  */
 package com.diffplug.blowdryer;
 
-
-import org.assertj.core.api.Assertions;
+import com.diffplug.blowdryer.Blowdryer.AuthPlugin;
+import com.diffplug.blowdryer.Blowdryer.ResourcePlugin;
+import com.diffplug.blowdryer.BlowdryerSetup.Bitbucket;
+import com.diffplug.blowdryer.BlowdryerSetup.GitAnchorType;
+import okhttp3.Request;
+import okhttp3.Request.Builder;
 import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Base64;
+import java.util.UUID;
+
+import static com.diffplug.blowdryer.BlowdryerSetup.BITBUCKET_COMMIT_HASH_CACHE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class BlowdryerTest {
 	private static final String JAR_FILE_RESOURCE_SEPARATOR = "!/";
@@ -28,23 +42,166 @@ public class BlowdryerTest {
 		filenameSafe("http://shortName.com/a+b-0-9~Z", "http-shortName.com-a+b-0-9-Z");
 		filenameSafe("https://raw.githubusercontent.com/diffplug/durian-build/07f588e52eb0f31e596eab0228a5df7233a98a14/gradle/spotless/spotless.license.java",
 				"https-raw.githubusercontent.com-diffplug--3vpUTw--14-gradle-spotless-spotless.license.java");
+		filenameSafe("https://raw.githubusercontent.com/diffplug/durian-build/07f588e52eb0f31e596eab0228a5df7233a98a14/gradle/spotless/spotless.license.java?at=refs/heads/master",
+			"https-raw.githubusercontent.com-diffplug--Sg5TNw---refs-heads-master-spotless.license.java");
+		filenameSafe("https://raw.githubusercontent.com/diffplug/durian-build/07f588e52eb0f31e596eab0228a5df7233a98a14/gradle/spotless/spotless.license.java?at=refs%2Fheads%2Fmaster",
+			"https-raw.githubusercontent.com-diffplug--s+tWqw--s-2Fheads-2Fmaster-spotless.license.java");
 	}
 
 	private void filenameSafe(String url, String safe) {
-		Assertions.assertThat(Blowdryer.filenameSafe(url)).isEqualTo(safe);
+		assertThat(Blowdryer.filenameSafe(url)).isEqualTo(safe);
 	}
 
 	@Test
 	public void cachedFileDeleted_issue_11() {
 		String test = "https://raw.githubusercontent.com/diffplug/blowdryer/test/2/b/src/main/resources/sample";
-		Assertions.assertThat(Blowdryer.immutableUrl(test)).hasContent("b");
+		assertThat(Blowdryer.immutableUrl(test)).hasContent("b");
 		Blowdryer.immutableUrl(test).delete();
-		Assertions.assertThat(Blowdryer.immutableUrl(test)).hasContent("b");
+		assertThat(Blowdryer.immutableUrl(test)).hasContent("b");
 	}
 
 	@Test
 	public void immutableUrlOfLocalJar() {
 		String jarFile = BlowdryerPluginTest.class.getResource("test.jar").getFile();
-		Assertions.assertThat(Blowdryer.immutableUrl(FILE_PROTOCOL + jarFile + JAR_FILE_RESOURCE_SEPARATOR + "sample")).exists();
+		assertThat(Blowdryer.immutableUrl(FILE_PROTOCOL + jarFile + JAR_FILE_RESOURCE_SEPARATOR + "sample")).exists();
 	}
+
+	@Test
+	public void bitbucketCloud_tagAnchorType() throws Exception {
+		final String hashRequestUrl = "https://api.bitbucket.org/2.0/repositories/testOrg/testRepo/refs/tags/testAnchor";
+		final String hash = UUID.randomUUID().toString();
+		final String expected = "https://api.bitbucket.org/2.0/repositories/testOrg/testRepo/src/" + hash + "/src/main/resources/test.properties";
+		BITBUCKET_COMMIT_HASH_CACHE.put(hashRequestUrl, hash);
+
+		setupBitbucketTestTarget(GitAnchorType.TAG).cloudAuth("un:pw");
+		final ResourcePlugin target = getResourcePlugin();
+
+		assertThat(target.toImmutableUrl("test.properties")).isEqualTo(expected);
+	}
+
+	@Test
+	public void bitbucketCloud_commitAnchorType() throws Exception {
+		final String expected = "https://api.bitbucket.org/2.0/repositories/testOrg/testRepo/src/testAnchor/src/main/resources/test.properties";
+		setupBitbucketTestTarget(GitAnchorType.COMMIT);
+		final ResourcePlugin target = getResourcePlugin();
+
+		assertThat(target.toImmutableUrl("test.properties")).isEqualTo(expected);
+	}
+
+	@Test
+	public void bitbucketCloud_branchAnchorType() throws Exception {
+		final String hashRequestUrl = "https://api.bitbucket.org/2.0/repositories/testOrg/testRepo/refs/branches/testAnchor";
+		final String hash = UUID.randomUUID().toString();
+		final String expected = "https://api.bitbucket.org/2.0/repositories/testOrg/testRepo/src/" + hash + "/src/main/resources/test.properties";
+		BITBUCKET_COMMIT_HASH_CACHE.put(hashRequestUrl, hash);
+
+		setupBitbucketTestTarget(GitAnchorType.BRANCH).cloudAuth("un:pw");
+		final ResourcePlugin target = getResourcePlugin();
+
+		assertThat(target.toImmutableUrl("test.properties")).isEqualTo(expected);
+	}
+
+	@Test
+	public void bitbucketCloud_treeAnchorType() throws Exception {
+		setupBitbucketTestTarget(GitAnchorType.TREE);
+		final ResourcePlugin target = getResourcePlugin();
+
+		assertThatThrownBy(() -> target.toImmutableUrl("test.properties"))
+			.isInstanceOf(UnsupportedOperationException.class)
+			.hasMessage("TREE hash resolution is not supported.");
+	}
+
+	@Test
+	public void bitbucketServer_tagAnchorType() throws Exception {
+		final String expected = "https://my.bitbucket.com/projects/testOrg/repos/testRepo/raw/src/main/resources/test.properties?at=refs%2Ftags%2FtestAnchor";
+		setupBitbucketTestTarget(GitAnchorType.TAG).server().customDomainHttps("my.bitbucket.com");
+		final ResourcePlugin target = getResourcePlugin();
+
+		assertThat(target.toImmutableUrl("test.properties")).isEqualTo(expected);
+	}
+
+	@Test
+	public void bitbucketServer_commitAnchorType() throws Exception {
+		final String expected = "https://my.bitbucket.com/projects/testOrg/repos/testRepo/raw/src/main/resources/test.properties?at=testAnchor";
+		setupBitbucketTestTarget(GitAnchorType.COMMIT).server().customDomainHttps("my.bitbucket.com");
+		final ResourcePlugin target = getResourcePlugin();
+
+		assertThat(target.toImmutableUrl("test.properties")).isEqualTo(expected);
+	}
+
+	@Test
+	public void bitbucketServer_branchAnchorType() throws Exception {
+		final String expected = "https://my.bitbucket.com/projects/testOrg/repos/testRepo/raw/src/main/resources/test.properties?at=refs%2Fheads%2FtestAnchor";
+		setupBitbucketTestTarget(GitAnchorType.BRANCH).server().customDomainHttps("my.bitbucket.com");
+		final ResourcePlugin target = getResourcePlugin();
+
+		assertThat(target.toImmutableUrl("test.properties")).isEqualTo(expected);
+	}
+
+	@Test
+	public void bitbucketServer_treeAnchorType() throws Exception {
+		setupBitbucketTestTarget(GitAnchorType.TREE).server().customDomainHttps("my.bitbucket.com");
+		final ResourcePlugin target = getResourcePlugin();
+
+		assertThatThrownBy(() -> target.toImmutableUrl("test.properties"))
+			.isInstanceOf(UnsupportedOperationException.class)
+			.hasMessage("TREE hash resolution is not supported.");
+	}
+
+	@Test
+	public void bitbucketServerAuth() throws Exception {
+		final String expected = "https://my.bitbucket.com/projects/testOrg/repos/testRepo/raw/src/main/resources/test.properties?at=refs%2Fheads%2FtestAnchor";
+		final String personalAccessToken = randomUUID();
+		setupBitbucketTestTarget(GitAnchorType.BRANCH).serverAuth(personalAccessToken).customDomainHttps("my.bitbucket.com");
+		final ResourcePlugin target = getResourcePlugin();
+
+		final AuthPlugin otherTarget = getAuthPlugin();
+		final Builder requestBuilder = new Builder().url(expected);
+		otherTarget.addAuthToken(expected, requestBuilder);
+		final Request request = requestBuilder.build();
+
+		assertThat(target.toImmutableUrl("test.properties")).isEqualTo(expected);
+		assertThat(request.header("Authorization")).isEqualTo(String.format("Bearer %s", personalAccessToken));
+	}
+
+	@Test
+	public void bitbucketCloudAuth() throws Exception {
+		final String expected = "https://api.bitbucket.org/2.0/repositories/testOrg/testRepo/src/testAnchor/src/main/resources/test.properties";
+    final String usernameAndAppPassword = String.format("%s:%s", randomUUID(), randomUUID());
+		setupBitbucketTestTarget(GitAnchorType.COMMIT).cloudAuth(usernameAndAppPassword);
+
+		final ResourcePlugin target = getResourcePlugin();
+		final AuthPlugin otherTarget = getAuthPlugin();
+		final Builder requestBuilder = new Builder().url(expected);
+		otherTarget.addAuthToken(expected, requestBuilder);
+		final Request request = requestBuilder.build();
+
+		assertThat(target.toImmutableUrl("test.properties")).isEqualTo(expected);
+		final String encoded = Base64.getEncoder().encodeToString((usernameAndAppPassword)
+			.getBytes(UTF_8));
+		assertThat(request.header("Authorization")).isEqualTo(String.format("Basic %s", encoded));
+	}
+
+	private Bitbucket setupBitbucketTestTarget(final GitAnchorType anchorType) {
+		final String repoOrg = "testOrg/testRepo";
+		final String anchor = "testAnchor";
+		return new BlowdryerSetup(null).bitbucket(repoOrg, anchorType, anchor);
+	}
+
+	private ResourcePlugin getResourcePlugin() throws Exception {
+		final Field field = Blowdryer.class.getDeclaredField("plugin");
+		field.setAccessible(true);
+		return (ResourcePlugin) field.get(null);
+	}
+
+	private AuthPlugin getAuthPlugin() throws Exception {
+		final Field field = Blowdryer.class.getDeclaredField("authPlugin");
+		field.setAccessible(true);
+		return (AuthPlugin) field.get(null);
+	}
+
+	private String randomUUID() {
+		return UUID.randomUUID().toString();
+	}
+
 }

--- a/src/test/java/com/diffplug/blowdryer/GradleHarness.java
+++ b/src/test/java/com/diffplug/blowdryer/GradleHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2020 DiffPlug
+ * Copyright (C) 2018-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/diffplug/blowdryer/GradleHarness.java
+++ b/src/test/java/com/diffplug/blowdryer/GradleHarness.java
@@ -25,8 +25,4 @@ public class GradleHarness extends ResourceHarness {
 		return GradleRunner.create().withProjectDir(rootFolder()).withPluginClasspath();
 	}
 
-	/** A GradleRunner with debugger attached. */
-	protected GradleRunner gradleRunnerDebug() throws IOException {
-		return GradleRunner.create().withProjectDir(rootFolder()).withDebug(true).withPluginClasspath();
-	}
 }

--- a/src/test/java/com/diffplug/blowdryer/GradleHarness.java
+++ b/src/test/java/com/diffplug/blowdryer/GradleHarness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2021 DiffPlug
+ * Copyright (C) 2018-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,5 +24,4 @@ public class GradleHarness extends ResourceHarness {
 	protected GradleRunner gradleRunner() throws IOException {
 		return GradleRunner.create().withProjectDir(rootFolder()).withPluginClasspath();
 	}
-
 }

--- a/src/test/java/com/diffplug/blowdryer/GradleHarness.java
+++ b/src/test/java/com/diffplug/blowdryer/GradleHarness.java
@@ -24,4 +24,9 @@ public class GradleHarness extends ResourceHarness {
 	protected GradleRunner gradleRunner() throws IOException {
 		return GradleRunner.create().withProjectDir(rootFolder()).withPluginClasspath();
 	}
+
+	/** A GradleRunner with debugger attached. */
+	protected GradleRunner gradleRunnerDebug() throws IOException {
+		return GradleRunner.create().withProjectDir(rootFolder()).withDebug(true).withPluginClasspath();
+	}
 }


### PR DESCRIPTION
- `filenameSafe` now removes query parameters and appends file name to the end of the link to preserve its original file extension.
- Support for Bitbucket Cloud and Server
