### PR TITLE
Preserve file extensions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
       - run:
           name: gradlew check
           command: ./gradlew check --build-cache
+      - store_test_results:
+          path: build/test-results/test
       - save_cache:
           paths:
             - ~/.gradle/wrapper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `干.file('blah.foo')` now preserves `.foo` extension in the returned file ([#23](https://github.com/diffplug/blowdryer/pull/23)).
+  - also, `干.immutableUrl(String url)` can take an optional second argument for specifying the file extension, e.g.
+    - `干.immutableUrl('https://foo.org/?file=blah.foo&rev=7')` returns a file which ends in `.foo-rev-7`
+    - `干.immutableUrl('https://foo.org/?file=blah.foo&rev=7', '.foo')` returns a file which ends in `.foo`
 
 ## [1.3.0] - 2021-06-23
-
 ### Added
 - Support for Bitbucket Cloud and Server ([#23](https://github.com/diffplug/blowdryer/pull/23)).
 

--- a/README.md
+++ b/README.md
@@ -166,11 +166,14 @@ You have to apply the `com.diffplug.blowdryerSetup` plugin in your `settings.gra
 
 ```gradle
 // com.diffplug.blowdryer.干 is alias of com.diffplug.blowdryer.Blowdryer
-static File   干.immutableUrl(String guaranteedImmutableUrl)
 static File   干.file(String resource)
 static String 干.prop(String propFile, String key)
 static String 干.proj(Project proj, String String key, String description)
 static <T> T  干.proj(Project proj, Class<T> clazz, String String key, String description)
+static File   干.immutableUrl(String guaranteedImmutableUrl)
+static File   干.immutableUrl(String guaranteedImmutableUrl, String fileSuffix)
+  // 干.immutableUrl('https://foo.org/?file=blah.foo&rev=7') returns a file which ends in `.foo-rev-7`
+  // 干.immutableUrl('https://foo.org/?file=blah.foo&rev=7', '.foo') returns a file which ends in `.foo`
 ```
 
 - [javadoc `BlowdryerSetup`](https://javadoc.io/static/com.diffplug/blowdryer/1.3.0/com/diffplug/blowdryer/BlowdryerSetup.html)

--- a/src/main/java/com/diffplug/blowdryer/Blowdryer.java
+++ b/src/main/java/com/diffplug/blowdryer/Blowdryer.java
@@ -127,6 +127,12 @@ public class Blowdryer {
 						throw new IllegalStateException("Expected url " + url + " but was " + propUrl + ", recommend deleting file at " + metaFile.getAbsolutePath());
 					}
 				} else {
+					if (metaFile.exists()) {
+						metaFile.delete();
+					}
+					if (dataFile.exists()) {
+						dataFile.delete();
+					}
 					Files.createParentDirs(dataFile);
 					download(url, dataFile);
 					Properties props = new Properties();

--- a/src/main/java/com/diffplug/blowdryer/Blowdryer.java
+++ b/src/main/java/com/diffplug/blowdryer/Blowdryer.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
+import javax.annotation.Nullable;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -87,6 +88,18 @@ public class Blowdryer {
 	 * This is appropriate only for immutable URLs, such as specific hashes from Git.
 	 */
 	public static File immutableUrl(String url) {
+		return immutableUrl(url, null);
+	}
+
+	/**
+	 * Downloads the given url to a local file in the system temporary directory.
+	 * It will only be downloaded once, system-wide, and it will not be checked for updates.
+	 * This is appropriate only for immutable URLs, such as specific hashes from Git.
+	 * 
+	 * If requiredSuffix is non-null, it is guaranteed that the returned filename will end
+	 * with that string.
+	 */
+	public static File immutableUrl(String url, @Nullable String requiredSuffix) {
 		synchronized (Blowdryer.class) {
 			File result = urlToContent.get(url);
 			if (result != null && result.isFile()) {
@@ -94,7 +107,10 @@ public class Blowdryer {
 			}
 
 			String safe = filenameSafe(url);
-			File metaFile = new File(cacheDir, safe + ".properties");
+			if (requiredSuffix != null && !safe.endsWith(requiredSuffix)) {
+				safe = safe + requiredSuffix;
+			}
+			File metaFile = new File(cacheDir, "meta_" + safe + ".properties");
 			File dataFile = new File(cacheDir, safe);
 
 			try {

--- a/src/main/java/com/diffplug/blowdryer/Blowdryer.java
+++ b/src/main/java/com/diffplug/blowdryer/Blowdryer.java
@@ -287,7 +287,9 @@ public class Blowdryer {
 			if (plugin instanceof DevPlugin) {
 				return new File(((DevPlugin) plugin).root, resourcePath);
 			} else {
-				return immutableUrl(plugin.toImmutableUrl(resourcePath));
+				int lastDot = resourcePath.lastIndexOf('.');
+				String preserveExtension = lastDot == -1 ? null : resourcePath.substring(lastDot);
+				return immutableUrl(plugin.toImmutableUrl(resourcePath), preserveExtension);
 			}
 		}
 	}
@@ -384,6 +386,11 @@ public class Blowdryer {
 		/** Alias for {@link Blowdryer#immutableUrl(String)}. */
 		public File immutableUrl(String url) {
 			return Blowdryer.immutableUrl(url);
+		}
+
+		/** Alias for {@link Blowdryer#immutableUrl(String, String)}. */
+		public File immutableUrl(String url, @Nullable String requiredSuffix) {
+			return Blowdryer.immutableUrl(url, requiredSuffix);
 		}
 
 		/** Alias for {@link Blowdryer#file(String)}. */

--- a/src/main/java/com/diffplug/blowdryer/Blowdryer.java
+++ b/src/main/java/com/diffplug/blowdryer/Blowdryer.java
@@ -194,7 +194,6 @@ public class Blowdryer {
 
 	/** Returns either the filename safe URL, or (first40)--(Base64 filenamesafe)(last40). */
 	static String filenameSafe(String url) {
-		url = preserveFileExtensionBitbucket(url);
 		String allSafeCharacters = url.replaceAll("[^a-zA-Z0-9-+_.]", "-");
 		String noDuplicateDash = allSafeCharacters.replaceAll("-+", "-");
 		if (noDuplicateDash.length() <= MAX_FILE_LENGTH) {
@@ -211,19 +210,6 @@ public class Blowdryer {
 					.replace('/', '-').replace('=', '-');
 			return first + "--" + hashed + end;
 		}
-	}
-
-	// preserve the filename and extension if query parameters are present in original url.
-	// required to retrieve XML files.
-	// From: https://mycompany.bitbucket.com/projects/PRJ/repos/my-repo/raw/src/main/resources/checkstyle/spotless.gradle?at=07f588e52eb0f31e596eab0228a5df7233a98a14
-	// To:   https://mycompany.bitbucket.com/projects/PRJ/repos/my-repo/raw/src/main/resources/checkstyle/spotless.gradle?at=07f588e52eb0f31e596eab0228a5df7233a98a14-spotless.gradle
-	private static String preserveFileExtensionBitbucket(String url) {
-		int atIdx = url.indexOf("?at=");
-		if (atIdx != -1) {
-			String fileNameWithoutQuery = url.substring(0, atIdx);
-			url = String.format("%s-%s", url, fileNameWithoutQuery.substring(fileNameWithoutQuery.lastIndexOf("/") + 1));
-		}
-		return url;
 	}
 
 	//////////////////////

--- a/src/main/java/com/diffplug/blowdryer/Blowdryer.java
+++ b/src/main/java/com/diffplug/blowdryer/Blowdryer.java
@@ -101,7 +101,8 @@ public class Blowdryer {
 	 */
 	public static File immutableUrl(String url, @Nullable String requiredSuffix) {
 		synchronized (Blowdryer.class) {
-			File result = urlToContent.get(url);
+			String cacheKey = requiredSuffix == null ? url : url + "|" + requiredSuffix; // | is illegal in URLs
+			File result = urlToContent.get(cacheKey);
 			if (result != null && result.isFile()) {
 				return result;
 			}
@@ -121,7 +122,7 @@ public class Blowdryer {
 						throw new IllegalArgumentException("Unexpected content, recommend deleting file at " + metaFile);
 					}
 					if (propUrl.equals(url)) {
-						urlToContent.put(url, dataFile);
+						urlToContent.put(cacheKey, dataFile);
 						return dataFile;
 					} else {
 						throw new IllegalStateException("Expected url " + url + " but was " + propUrl + ", recommend deleting file at " + metaFile.getAbsolutePath());
@@ -142,7 +143,7 @@ public class Blowdryer {
 					try (OutputStream output = Files.asByteSink(metaFile).openBufferedStream()) {
 						props.store(output, "");
 					}
-					urlToContent.put(url, dataFile);
+					urlToContent.put(cacheKey, dataFile);
 					return dataFile;
 				}
 			} catch (IOException | URISyntaxException e) {

--- a/src/main/java/com/diffplug/blowdryer/干.java
+++ b/src/main/java/com/diffplug/blowdryer/干.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 DiffPlug
+ * Copyright (C) 2019-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.diffplug.blowdryer;
 
 import java.io.File;
 import java.io.IOException;
+import javax.annotation.Nullable;
 import org.gradle.api.Project;
 
 /** Alias for {@link Blowdryer}. */
@@ -27,6 +28,11 @@ public class 干 {
 	/** Alias for {@link Blowdryer#immutableUrl(String)}. */
 	public static File immutableUrl(String url) {
 		return Blowdryer.immutableUrl(url);
+	}
+
+	/** Alias for {@link Blowdryer#immutableUrl(String, String)}. */
+	public File immutableUrl(String url, @Nullable String requiredSuffix) {
+		return Blowdryer.immutableUrl(url, requiredSuffix);
 	}
 
 	/** Alias for {@link Blowdryer#file(String)}. */

--- a/src/test/java/com/diffplug/blowdryer/BlowdryerTest.java
+++ b/src/test/java/com/diffplug/blowdryer/BlowdryerTest.java
@@ -25,7 +25,6 @@ import com.diffplug.blowdryer.Blowdryer.AuthPlugin;
 import com.diffplug.blowdryer.Blowdryer.ResourcePlugin;
 import com.diffplug.blowdryer.BlowdryerSetup.Bitbucket;
 import com.diffplug.blowdryer.BlowdryerSetup.GitAnchorType;
-import java.io.File;
 import java.lang.reflect.Field;
 import java.util.Base64;
 import java.util.UUID;
@@ -65,8 +64,8 @@ public class BlowdryerTest {
 	@Test
 	public void requiredSuffix() {
 		String jarFile = BlowdryerPluginTest.class.getResource("test.jar").getFile();
-		File fileWithSuffix = Blowdryer.immutableUrl(FILE_PROTOCOL + jarFile + JAR_FILE_RESOURCE_SEPARATOR + "sample", ".suffix");
-		assertThat(fileWithSuffix.getName()).endsWith(".suffix");
+		assertThat(Blowdryer.immutableUrl(FILE_PROTOCOL + jarFile + JAR_FILE_RESOURCE_SEPARATOR + "sample", ".suffix").getName()).endsWith(".suffix");
+		assertThat(Blowdryer.immutableUrl(FILE_PROTOCOL + jarFile + JAR_FILE_RESOURCE_SEPARATOR + "sample", ".suffix2").getName()).endsWith(".suffix2");
 	}
 
 	@Test

--- a/src/test/java/com/diffplug/blowdryer/BlowdryerTest.java
+++ b/src/test/java/com/diffplug/blowdryer/BlowdryerTest.java
@@ -25,6 +25,7 @@ import com.diffplug.blowdryer.Blowdryer.AuthPlugin;
 import com.diffplug.blowdryer.Blowdryer.ResourcePlugin;
 import com.diffplug.blowdryer.BlowdryerSetup.Bitbucket;
 import com.diffplug.blowdryer.BlowdryerSetup.GitAnchorType;
+import java.io.File;
 import java.lang.reflect.Field;
 import java.util.Base64;
 import java.util.UUID;
@@ -41,10 +42,6 @@ public class BlowdryerTest {
 		filenameSafe("http://shortName.com/a+b-0-9~Z", "http-shortName.com-a+b-0-9-Z");
 		filenameSafe("https://raw.githubusercontent.com/diffplug/durian-build/07f588e52eb0f31e596eab0228a5df7233a98a14/gradle/spotless/spotless.license.java",
 				"https-raw.githubusercontent.com-diffplug--3vpUTw--14-gradle-spotless-spotless.license.java");
-		filenameSafe("https://mycompany.bitbucket.com/projects/PRJ/repos/my-repo/raw/src/main/resources/checkstyle/spotless.gradle?at=refs%2Fheads%2Fmaster",
-				"https-mycompany.bitbucket.com-projects-P--7T3UGg--at-refs-2Fheads-2Fmaster-spotless.gradle");
-		filenameSafe("https://mycompany.bitbucket.com/projects/PRJ/repos/my-repo/raw/src/main/resources/checkstyle/spotless.gradle?at=07f588e52eb0f31e596eab0228a5df7233a98a14",
-				"https-mycompany.bitbucket.com-projects-P--K+HRow--596eab0228a5df7233a98a14-spotless.gradle");
 	}
 
 	private void filenameSafe(String url, String safe) {
@@ -63,6 +60,13 @@ public class BlowdryerTest {
 	public void immutableUrlOfLocalJar() {
 		String jarFile = BlowdryerPluginTest.class.getResource("test.jar").getFile();
 		assertThat(Blowdryer.immutableUrl(FILE_PROTOCOL + jarFile + JAR_FILE_RESOURCE_SEPARATOR + "sample")).exists();
+	}
+
+	@Test
+	public void requiredSuffix() {
+		String jarFile = BlowdryerPluginTest.class.getResource("test.jar").getFile();
+		File fileWithSuffix = Blowdryer.immutableUrl(FILE_PROTOCOL + jarFile + JAR_FILE_RESOURCE_SEPARATOR + "sample", ".suffix");
+		assertThat(fileWithSuffix.getName()).endsWith(".suffix");
 	}
 
 	@Test

--- a/src/test/java/com/diffplug/blowdryer/BlowdryerTest.java
+++ b/src/test/java/com/diffplug/blowdryer/BlowdryerTest.java
@@ -38,6 +38,7 @@ public class BlowdryerTest {
 
 	@Test
 	public void filenameSafe() {
+		filenameSafe("https://foo.org/?file=blah.foo&rev=7", "https-foo.org-file-blah.foo-rev-7");
 		filenameSafe("http://shortName.com/a+b-0-9~Z", "http-shortName.com-a+b-0-9-Z");
 		filenameSafe("https://raw.githubusercontent.com/diffplug/durian-build/07f588e52eb0f31e596eab0228a5df7233a98a14/gradle/spotless/spotless.license.java",
 				"https-raw.githubusercontent.com-diffplug--3vpUTw--14-gradle-spotless-spotless.license.java");


### PR DESCRIPTION
We generate filenames based on URLs, but some script sources (namely GitLab and Bitbucket) don't end with the filename, which means that we lose the file extension. Some Gradle plugins (e.g. checkstyle) require that the input files have a certain extension.

We currently fix this in a haphazard way for Bitbucket, but not at all for GitLab. This PR adds a reliable way to ensure that file extensions are preserved.